### PR TITLE
Update guix version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       DOCKER_BUILDKIT: 1
-      METACALL_GUIX_VERSION: 1.3.0
+      METACALL_GUIX_VERSION: 1.4.0
       METACALL_GUIX_ARCH: x86_64
 
     steps:

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ For building it, we use `buildx` from Buildkit:
 # Run the following command the first time only
 docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
 # Build the Guix image with the following command
-docker buildx build -t metacall/guix --allow security.insecure --build-arg METACALL_GUIX_VERSION="1.3.0" --build-arg METACALL_GUIX_ARCH="x86_64" .
+docker buildx build -t metacall/guix --allow security.insecure --build-arg METACALL_GUIX_VERSION="1.4.0" --build-arg METACALL_GUIX_ARCH="x86_64" .
 ```

--- a/channels/channels.scm
+++ b/channels/channels.scm
@@ -20,5 +20,5 @@
        (name 'guix)
        (url "https://git.savannah.gnu.org/git/guix.git")
        (branch "master")
-       (commit "5b35626374783c019ba0911b612e1385f238dfbe")) ; Wed Sep 14 11:07:49 2022 +0200
+       (commit "6311493d7a6271bfbc51f4693857f9a12fe9965d")) ; Wed Apr 5 18:17:00 2023 +0200
 )


### PR DESCRIPTION
Hi, thanks for your maintenance of this Dockerfile.
It is very useful to use guix in Docker!

I update guix to 1.4.0 and make it to use [latest commit](https://git.savannah.gnu.org/cgit/guix.git/commit/?id=6311493d7a6271bfbc51f4693857f9a12fe9965d) on guix channel.