### PR TITLE
Add multi-architecture Docker builds for Guix image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,8 @@ jobs:
           outputs: type=image,name=docker.io/${{ env.REGISTRY_IMAGE }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           allow: security.insecure
           build-args: |
-            METACALL_GUIX_VERSION="${{ env.GUIX_VERSION }}"
-            METACALL_GUIX_ARCH="${{ matrix.platform.guix }}"
+            METACALL_GUIX_VERSION=${{ env.GUIX_VERSION }}
+            METACALL_GUIX_ARCH=${{ matrix.platform.guix }}
       
       - name: Export digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           allow: security.insecure
           build-args: |
             METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION"
-            METACALL_GUIX_ARCH="${{ matrix.guix.platform }}"
+            METACALL_GUIX_ARCH="${{ matrix.platform.guix }}"
       
       - name: Export digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Create a new builder instance
         run: docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
       
-      - name: Authenticate to Docker registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+   #   - name: Authenticate to Docker registry
+    #    if: github.event_name != 'pull_request'
+     #   uses: docker/login-action@v2
+      #  with:
+       #   username: ${{ secrets.DOCKER_USERNAME }}
+        #  password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push image
-        run: docker buildx build -t metacall/guix --output type=image,name=docker.io/metacall/guix:${GITHUB_SHA},push=${{ github.event_name != 'pull_request' }} --allow security.insecure --build-arg METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION" --build-arg METACALL_GUIX_ARCH="$METACALL_GUIX_ARCH" .
+        run: docker buildx build -t metacall/guix --output type=image,name=docker.io/metacall/guix:${GITHUB_SHA} --allow security.insecure --build-arg METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION" --build-arg METACALL_GUIX_ARCH="$METACALL_GUIX_ARCH" .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DOCKER_BUILDKIT: 1
       REGISTRY_IMAGE: metacall/guix
-      METACALL_GUIX_VERSION: 1.4.0
+      GUIX_VERSION: 1.4.0
+      DOCKER_BUILDKIT: 1
 
     strategy:
       fail-fast: false
@@ -47,7 +47,7 @@ jobs:
       - name: Docker Setup BuildX
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.5.1
+          version: v${{ env.BUILDKIT_VERSION }
 
       - name: Verify Docker BuildX Version
         run: docker buildx version
@@ -71,7 +71,7 @@ jobs:
           outputs: type=image,name=docker.io/${{ env.REGISTRY_IMAGE }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           allow: security.insecure
           build-args: |
-            METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION"
+            METACALL_GUIX_VERSION="${{ env.GUIX_VERSION }}"
             METACALL_GUIX_ARCH="${{ matrix.platform.guix }}"
       
       - name: Export digest
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.5.1
+          version: v${{ env.BUILDKIT_VERSION }}
       
       - name: Docker meta
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Docker Setup BuildX
         uses: docker/setup-buildx-action@v3
         with:
-          version: v${{ env.BUILDKIT_VERSION }
+          version: v${{ env.BUILDKIT_VERSION }}
 
       - name: Verify Docker BuildX Version
         run: docker buildx version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       REGISTRY_IMAGE: metacall/guix
       GUIX_VERSION: 1.4.0
-      DOCKER_BUILDKIT: 1
+      BUILDKIT_VERSION: 0.5.1
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,15 @@ jobs:
         platform: [
           { docker: linux/amd64, guix: x86_64-linux },
           { docker: linux/386, guix: i686-linux },
-          { docker: linux/arm/v7, guix: armhf-linux },
-          { docker: linux/arm64/v8, guix: aarch64-linux },
-          { docker: linux/ppc64le, guix: powerpc64le-linux }
+
+          # TODO:
+
+          # guix error: cloning builder process: Invalid argument (https://lists.gnu.org/archive/html/help-guix/2017-12/msg00023.html)
+          # { docker: linux/arm/v7, guix: armhf-linux },
+
+          # ERROR: failed to solve: ResourceExhausted: process "/bin/sh -c sh -c '/entry-point.sh guix pull ..." did not complete successfully: cannot allocate memory
+          # { docker: linux/arm64/v8, guix: aarch64-linux },
+          # { docker: linux/ppc64le, guix: powerpc64le-linux }
         ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         platform: [
           { docker: linux/amd64, guix: x86_64-linux },
+          { docker: linux/386, guix: i686-linux },
           { docker: linux/arm/v7, guix: armhf-linux },
           { docker: linux/arm64/v8, guix: aarch64-linux },
-          { docker: linux/ppc64le, guix: powerpc64le-linux },
-          { docker: linux/386, guix: i686-linux }
+          { docker: linux/ppc64le, guix: powerpc64le-linux }
         ]
 
     steps:
@@ -91,6 +91,7 @@ jobs:
           retention-days: 1
 
   merge:
+    name: Merge digests for the manifest
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       REGISTRY_IMAGE: metacall/guix
       GUIX_VERSION: 1.4.0
-      BUILDKIT_VERSION: 0.5.1
+      BUILDKIT_VERSION: 0.13.0
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,14 @@ jobs:
     name: Build the Docker image
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        docker_arch: [linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/386]
+        guix_arch: [x86_64-linux, aarch64-linux, armv7-linux, powerpc64le-linux, i686-linux]
+
     env:
       DOCKER_BUILDKIT: 1
       METACALL_GUIX_VERSION: 1.4.0
-      METACALL_GUIX_ARCH: x86_64
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -10,28 +9,43 @@ on:
       - 'v*.*.*'
 
 jobs:
-
   build:
     name: Build the Docker image
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        docker_arch: [linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/386]
-        guix_arch: [x86_64-linux, aarch64-linux, armv7-linux, powerpc64le-linux, i686-linux]
-
     env:
       DOCKER_BUILDKIT: 1
+      REGISTRY_IMAGE: metacall/guix
       METACALL_GUIX_VERSION: 1.4.0
 
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          { docker: linux/amd64, guix: x86_64-linux },
+          { docker: linux/arm/v7, guix: armhf-linux },
+          { docker: linux/arm64/v8, guix: aarch64-linux },
+          { docker: linux/ppc64le, guix: powerpc64le-linux },
+          { docker: linux/386, guix: i686-linux }
+        ]
+
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
+      - name: Prepare
+        run: |
+          platform=${{ matrix.docker.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          fetch-depth: 0
+          images: ${{ env.REGISTRY_IMAGE }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Docker Setup BuildX
-        uses: docker/setup-buildx-action@v2.0.0
+        uses: docker/setup-buildx-action@v3
         with:
           version: v0.5.1
 
@@ -40,13 +54,78 @@ jobs:
       
       - name: Create a new builder instance
         run: docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
-      
-   #   - name: Authenticate to Docker registry
-    #    if: github.event_name != 'pull_request'
-     #   uses: docker/login-action@v2
-      #  with:
-       #   username: ${{ secrets.DOCKER_USERNAME }}
-        #  password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push image
-        run: docker buildx build -t metacall/guix --output type=image,name=docker.io/metacall/guix:${GITHUB_SHA} --allow security.insecure --build-arg METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION" --build-arg METACALL_GUIX_ARCH="$METACALL_GUIX_ARCH" .
+      - name: Authenticate to Docker registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.docker.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=docker.io/${{ env.REGISTRY_IMAGE }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          allow: security.insecure
+          build-args: |
+            METACALL_GUIX_VERSION="$METACALL_GUIX_VERSION"
+            METACALL_GUIX_ARCH="${{ matrix.guix.platform }}"
+      
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.5.1
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Authenticate to Docker registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY channels/ /root/.config/guix/
 # Run pull (https://github.com/docker/buildx/blob/master/README.md#--allowentitlement)
 # Restart with latest version of the daemon and garbage collect
 # Verify if the certificates exist and the version is correct (it is fixed to the channels.scm)
-RUN --security=insecure sh -c '/entry-point.sh guix pull -C && guix package --fallback -i nss-certs' \
+RUN --security=insecure sh -c '/entry-point.sh guix pull && guix package --fallback -i nss-certs' \
 	&& sh -c '/entry-point.sh guix gc && guix gc --optimize' \
 	&& [ -e /root/.guix-profile/etc/ssl/certs/ca-certificates.crt ] \
 	&& [ "`cat /root/.config/guix/channels.scm | grep commit | cut -d'"' -f 2`" = "`guix --version | head -n 1 | awk '{print $NF}'`" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /gnu/store \
 	&& for i in `seq -w 1 10`; do \
 			adduser -G guixbuild -h /var/empty -s `which nologin` -S guixbuilder$i; \
 		done \
-	&& wget -O - https://ftp.gnu.org/gnu/guix/guix-binary-${METACALL_GUIX_VERSION}.${METACALL_GUIX_ARCH}-linux.tar.xz | tar -xJv -C / \
+	&& wget -O - https://ftp.gnu.org/gnu/guix/guix-binary-${METACALL_GUIX_VERSION}.${METACALL_GUIX_ARCH}.tar.xz | tar -xJv -C / \
 	&& mkdir -p /root/.config/guix \
 	&& ln -sf /var/guix/profiles/per-user/root/current-guix /root/.config/guix/current \
 	&& mkdir -p /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY channels/ /root/.config/guix/
 # Run pull (https://github.com/docker/buildx/blob/master/README.md#--allowentitlement)
 # Restart with latest version of the daemon and garbage collect
 # Verify if the certificates exist and the version is correct (it is fixed to the channels.scm)
-RUN --security=insecure sh -c '/entry-point.sh guix pull && guix package --fallback -i nss-certs' \
+RUN --security=insecure sh -c '/entry-point.sh guix pull -C && guix package --fallback -i nss-certs' \
 	&& sh -c '/entry-point.sh guix gc && guix gc --optimize' \
 	&& [ -e /root/.guix-profile/etc/ssl/certs/ca-certificates.crt ] \
 	&& [ "`cat /root/.config/guix/channels.scm | grep commit | cut -d'"' -f 2`" = "`guix --version | head -n 1 | awk '{print $NF}'`" ]

--- a/channels/channels.scm
+++ b/channels/channels.scm
@@ -20,5 +20,5 @@
        (name 'guix)
        (url "https://git.savannah.gnu.org/git/guix.git")
        (branch "master")
-       (commit "67960be52e01f8bd169dcff5985c4af2c5f87f91")) ; Fri Feb 16 11:18:47 2024 +0100
+       (commit "8e2f32cee982d42a79e53fc1e9aa7b8ff0514714")) ; Sun Dec 18 16:01:32 2022 +0100
 )

--- a/channels/channels.scm
+++ b/channels/channels.scm
@@ -20,5 +20,5 @@
        (name 'guix)
        (url "https://git.savannah.gnu.org/git/guix.git")
        (branch "master")
-       (commit "67960be52e01f8bd169dcff5985c4af2c5f87f91")) ; Fri Feb 16 11:18:47 2024 +0100
+       (commit "8ffb0c14b8abdbb471788f993a7835add147e3a8")) ; Mon Oct 14 21:58:56 2024 +0100
 )

--- a/channels/channels.scm
+++ b/channels/channels.scm
@@ -20,5 +20,5 @@
        (name 'guix)
        (url "https://git.savannah.gnu.org/git/guix.git")
        (branch "master")
-       (commit "8e2f32cee982d42a79e53fc1e9aa7b8ff0514714")) ; Sun Dec 18 16:01:32 2022 +0100
+       (commit "67960be52e01f8bd169dcff5985c4af2c5f87f91")) ; Fri Feb 16 11:18:47 2024 +0100
 )


### PR DESCRIPTION
This title better reflects that the PR:

Implements multi-architecture support (amd64, arm/v7, arm64/v8, ppc64le, 386)
Specifically targets Docker image builds
Is for the Guix package manager image

This is more descriptive than just "Multi arch builds" and helps reviewers immediately understand the scope and purpose of the changes.

@viferga 